### PR TITLE
Update if statement to make nonce/domain mandatory

### DIFF
--- a/ssi_access_decision_point/credentials/verifier.py
+++ b/ssi_access_decision_point/credentials/verifier.py
@@ -49,14 +49,14 @@ def __verify_jwt_vp(jwt_vp, nonce, domain):
       'credentials': None
     }
 
-  if nonce and nonce != vp_verification_result['data']['challenge']['nonce']:
+  if nonce != vp_verification_result['data']['challenge']['nonce']:
     return {
       'valid': False,
       'reason': "Required nonce missing in VP",
       'holder': None,
       'credentials': None
     }
-  if domain and domain != vp_verification_result['data']['challenge']['domain']:
+  if domain != vp_verification_result['data']['challenge']['domain']:
     return {
       'valid': False,
       'reason': "Required domain missing in VP",


### PR DESCRIPTION
The original code seemed to make the nonce and domain variable optional when checking a Verifiable Presentation.

When verifying the VP in __verify_jwt_vp(), the original code checks for both whether a nonce exists and then whether it is equal to the nonce sent in the Verification Presentation Request. This means that it can only return 'valid: false' if a nonce exists, as a nonce not existing would fail the first condition and the code skips the rest of the check.

I believe the fix is simply removing the first condition, 'if nonce'. The code just below it for checking domain is similar and has the same fix.